### PR TITLE
Solved bugs when using ICache

### DIFF
--- a/hardware/src/ibex_top.sv
+++ b/hardware/src/ibex_top.sv
@@ -723,9 +723,10 @@ module ibex_top import ibex_pkg::*; #(
           .rdata_o     (ic_data_rdata[way]),
           .cfg_i       (ram_cfg_i)
         );
-
-        assign icache_tag_alert  = '{default:'b0};
-        assign icache_data_alert = '{default:'b0};
+        // assign icache_tag_alert  = '{default:'b0};
+        // assign icache_data_alert = '{default:'b0};
+        assign icache_tag_alert[way]  = 1'b0;
+        assign icache_data_alert[way] = 1'b0; 
       end
     end
 

--- a/hardware/src/iob_ibex.sv
+++ b/hardware/src/iob_ibex.sv
@@ -264,7 +264,7 @@ module iob_ibex import ibex_pkg::*; #(
    // ---- Fetch-enable (multi-bit) and optional reset request
    ibex_mubi_t  fetch_enable_core;
    logic        core_reset_req;
-
+   crash_dump_t crash_dump;  // 160-bit packed struct
 
    /*
    * Some parameters' definitions
@@ -273,7 +273,7 @@ module iob_ibex import ibex_pkg::*; #(
    parameter bit RV32E = 1'b0;
    parameter ibex_pkg::rv32m_e RV32M = ibex_pkg::RV32MNone;
    parameter ibex_pkg::rv32b_e RV32B = ibex_pkg::RV32BNone;
-   parameter ibex_pkg::regfile_e RegFile = ibex_pkg::RegFileFPGA;
+   parameter ibex_pkg::regfile_e RegFile = ibex_pkg::RegFileFF;
    parameter bit BranchTargetALU = 1'b0;
    parameter bit WritebackStage = 1'b0;
    parameter bit ICache = 1'b1;


### PR DESCRIPTION
When ICache was ON, and the chosen CACHE had multiple ways, the former

        assign icache_tag_alert  = '{default:'b0};
        assign icache_data_alert = '{default:'b0};
        
code lines generated a "multiple conflicting drivers" error due to the fact that this segment is placed on a _for_ loop, but isn't dependent on the loop iterator and, in each iteration, attempts to drive the full vector.
That segment is now dependent on the current loop iteration.


Plus, there was a floating signal in iob_ibex.sv that was generating warnings.